### PR TITLE
Message handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+endroid (2.0.2) UNRELEASED; urgency=medium
+
+  * Async chunking of messages above maximum webex message length
+  * Take out broken retry loop for retrieving events for membership adds, instead use fields within the activity structure 
+  * Deduce whether endroid is a moderator before attempting to kick member from moderated room  
+
+ -- Deborah Martin <debomart@ensoft-linux4.cisco.com>  Thu, 22 Oct 2020 14:02:38 +0100
+
 endroid (2.0.1) bionic; urgency=medium
 
   * Install service file to /etc/systemd/system/

--- a/src/endroid/__init__.py
+++ b/src/endroid/__init__.py
@@ -27,7 +27,7 @@ from endroid.database import Database
 import endroid.manhole
 
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 LOGGING_FORMAT = '%(asctime)-8s %(name)-20s %(levelname)-8s %(message)s'
 LOGGING_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'

--- a/src/endroid/__init__.py
+++ b/src/endroid/__init__.py
@@ -94,7 +94,7 @@ class Endroid(object):
         self.webexhandler.setHandlerParent(self.client)
         self.client.set_callbacks(connected=self.webexhandler.connected,
                                   on_message=self.webexhandler.onMessage,
-                                  on_membership=self.webexhandler.onMembership) 
+                                  on_membership=self.webexhandler.onMembership)
 
         self.usermanagement = UserManagement(self.webexhandler,
                                              self.conf)

--- a/src/endroid/usermanagement.py
+++ b/src/endroid/usermanagement.py
@@ -337,7 +337,8 @@ class UserManagement(object):
         Kicks the user from the room if not in the set of registered members
         for the room.
         """
-        if user not in self.get_users(room) and remove:
+        if room in self._rooms.registered and \
+           user not in self.get_users(room) and remove:
             self.wh.kick(user, room, "Unexpected user added to room")
 
     def joined_group(self, name):

--- a/src/endroid/webex_client.py
+++ b/src/endroid/webex_client.py
@@ -32,10 +32,6 @@ DEVICE_DATA = {
     "systemVersion":"0.1"
 }
 
-# Time in seconds to wait after an event notification before attempting to get
-# the event from webexteamssdk
-EVENT_WAIT = 1
-
 logger = logging.getLogger("webex-client")
 
 def catch_api_errors(func):
@@ -222,6 +218,8 @@ class WebexClient(object):
                 # Handle a message
                 logger.debug('activity verb is post, message id is %s',
                               activity['id'])
+                # See whether Endroid is still in the room before attempting to
+                # retrieve the message
                 try:
                     message = self.webex_api.messages.get(activity['id'])
 
@@ -236,7 +234,7 @@ class WebexClient(object):
                         logger.exception("Got exception processing message %s",
                                          activity['id'])
                 except Exception:
-                    logger.exception("Got exception processing message %s", 
+                    logger.exception("Got exception processing message %s",
                                      activity['id'])
 
             elif activity['verb'] == 'add':
@@ -244,39 +242,12 @@ class WebexClient(object):
                 # it may not be immediately findable.
                 logger.debug('activity verb is add, event id is %s',
                               activity['id'])
-                def _process_membership(eventId, attempt_num):
-                    try:
-                        event = self.webex_api.events.get(eventId=eventId)
-                        logger.info('Membership created for %s into %s room',
-                                    event.data.personEmail, event.data.roomId)
-                    except webexteamssdk.exceptions.ApiError as e:
-                        if attempt_num < 5:
-                            # If the event is still not findable, defer again.
-                            logger.error("Failed to lookup add event %s, "
-                                         "status code %s, retrying (%u)...", 
-                                         eventId, e.status_code, attempt_num)
-                            later = reactor.callLater(EVENT_WAIT,
-                                                      _process_membership, 
-                                                      eventId, attempt_num + 1)
-                        else:
-                            logger.error("Giving up lookup of add event after "
-                                         "%u retries", attempt_num)
-                        return
-                    except Exception:
-                        logger.exception("Got exception getting event %s", 
-                                         eventId)
-                        return
-
-                    try:
-                        self.on_membership(event.data)
-                    except Exception as e:
-                        logger.exception("Got exception processing membership "
-                                         "%s", eventId)
-
-                # Defer the membership get since events are not immediately
-                # findable.
-                later = reactor.callLater(EVENT_WAIT, _process_membership,
-                                          activity['id'], 1)
+                try:
+                    self.on_membership(activity['target']['globalId'],
+                                       activity['object']['emailAddress'])
+                except Exception as e:
+                    logger.exception("Got exception processing membership "
+                                     "%s", activity['id'])
 
     @catch_api_errors
     def _process_connected(self):

--- a/src/endroid/webex_client.py
+++ b/src/endroid/webex_client.py
@@ -245,7 +245,7 @@ class WebexClient(object):
                 try:
                     self.on_membership(activity['target']['globalId'],
                                        activity['object']['emailAddress'])
-                except Exception as e:
+                except Exception:
                     logger.exception("Got exception processing membership "
                                      "%s", activity['id'])
 


### PR DESCRIPTION
1. Async chunking of messages with size exceeding max webex message length
2. Use fields in activity structure to find room ID and user for member add notifications, rather getting an event in a looping call with retry handling. 
3. Deduce whether endroid is a moderator to pre-empt 403 errors when trying to kick users from moderated spaces when not a moderator. 404 errors for messages received when endroid has left the room not able to pre-empt as error incurred when getting member list for room not present in.
